### PR TITLE
score transports

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,9 @@ ruby "3.3.5"
 # Bundle edge Rails instead: gem "rails", github: "rails/rails", branch: "main"
 gem "rails", "~> 7.1.6"
 
+# Minitest 6 est incompatible avec le line_filtering de Rails 7.1 (ArgumentError au lancement des tests).
+gem "minitest", "~> 5.25"
+
 # The original asset pipeline for Rails [https://github.com/rails/sprockets-rails]
 gem "sprockets-rails"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -180,9 +180,7 @@ GEM
     marcel (1.1.0)
     matrix (0.4.3)
     mini_mime (1.1.5)
-    minitest (6.0.2)
-      drb (~> 2.0)
-      prism (~> 1.5)
+    minitest (5.27.0)
     msgpack (1.8.0)
     mutex_m (0.3.0)
     net-imap (0.6.3)
@@ -368,6 +366,7 @@ DEPENDENCIES
   font-awesome-sass (~> 6.1)
   importmap-rails
   jbuilder
+  minitest (~> 5.25)
   pg (~> 1.1)
   puma (>= 5.0)
   pundit
@@ -442,7 +441,7 @@ CHECKSUMS
   marcel (1.1.0) sha256=fdcfcfa33cc52e93c4308d40e4090a5d4ea279e160a7f6af988260fa970e0bee
   matrix (0.4.3) sha256=a0d5ab7ddcc1973ff690ab361b67f359acbb16958d1dc072b8b956a286564c5b
   mini_mime (1.1.5) sha256=8681b7e2e4215f2a159f9400b5816d85e9d8c6c6b491e96a12797e798f8bccef
-  minitest (6.0.2) sha256=db6e57956f6ecc6134683b4c87467d6dd792323c7f0eea7b93f66bd284adbc3d
+  minitest (5.27.0) sha256=2d3b17f8a36fe7801c1adcffdbc38233b938eb0b4966e97a6739055a45fa77d5
   msgpack (1.8.0) sha256=e64ce0212000d016809f5048b48eb3a65ffb169db22238fb4b72472fecb2d732
   mutex_m (0.3.0) sha256=cfcb04ac16b69c4813777022fdceda24e9f798e48092a2b817eb4c0a782b0751
   net-imap (0.6.3) sha256=9bab75f876596d09ee7bf911a291da478e0cd6badc54dfb82874855ccc82f2ad

--- a/app/assets/stylesheets/pages/_map.scss
+++ b/app/assets/stylesheets/pages/_map.scss
@@ -150,6 +150,23 @@
     gap: 0.2rem;
   }
 
+  // Détail du score transports : texte pédagogique + contributions pondérées
+  &__hint {
+    font-size: 0.72rem;
+    line-height: 1.35;
+    color: var(--gray-600);
+    margin-top: 0.25rem;
+    opacity: 0.92;
+  }
+
+  &__breakdown {
+    font-size: 0.7rem;
+    line-height: 1.35;
+    color: var(--gray-700);
+    margin-top: 0.2rem;
+    font-variant-numeric: tabular-nums;
+  }
+
   &__meta {
     font-size: 0.8rem;
     color: var(--gray-600);

--- a/app/javascript/controllers/map_controller.js
+++ b/app/javascript/controllers/map_controller.js
@@ -273,7 +273,15 @@ export default class extends Controller {
         </p>
         <ul class="map-popup__scores">
           <li>Emploi : ${props.job_market_score}</li>
-          <li>Transports : ${props.transport_network_score}</li>
+          <li>
+            Transports : <strong>${props.transport_network_score}</strong>
+            ${props.transport_network_caption
+              ? `<div class="map-popup__hint">${props.transport_network_caption}</div>`
+              : ""}
+            ${props.transport_component_train != null
+              ? `<div class="map-popup__breakdown">Train ×4 : ${props.transport_component_train} · Métro ×3 : ${props.transport_component_metro} · Tram ×2 : ${props.transport_component_tram} · Bus : ${props.transport_component_bus}</div>`
+              : ""}
+          </li>
           <li>Éducation : ${props.education_score}</li>
           <li>Santé : ${props.health_score}</li>
           <li>Soleil : ${props.sunshine_score}</li>

--- a/app/services/transport_network_score_calculator.rb
+++ b/app/services/transport_network_score_calculator.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+# Service object : calcule un score transports 0–100 et un détail pédagogique pour une commune.
+#
+# Pourquoi un service plutôt que du code dans le modèle City ?
+# Même logique que RealEstateScoreCalculator : la normalisation dépend du *jeu* de communes
+# (min / max sur le scope affiché), pas seulement d'une ligne en base — on garde le modèle léger.
+#
+# Méthode : indice brut = (TRAIN_valeur × 4) + (METRO_valeur × 3) + (TRAM_valeur × 2) + (BUS_valeur × 1).
+# Les *_valeur sont déjà normalisées par 1000 habitants (cf. README / import CSV).
+# Les poids reflètent l'importance relative des modes (capacité, attractivité du réseau lourd).
+#
+# Normalisation : min–max sur le scope, score élevé = meilleure offre relative (comme l'immobilier).
+# Le README mentionne aussi des rangs centiles côté pipeline données ; l'API carte utilise ici
+# min–max pour rester cohérent avec RealEstateScoreCalculator et explicite mathématiquement.
+class TransportNetworkScoreCalculator
+  WEIGHTS = {
+    train: 4,
+    metro: 3,
+    tram: 2,
+    bus: 1
+  }.freeze
+
+  def initialize(scope)
+    @cities = Array(scope)
+    @indices = @cities.map { |city| self.class.weighted_index(city) }
+    @min = @indices.min
+    @max = @indices.max
+  end
+
+  # Calcule les résultats pour toutes les villes du scope : une seule passe min/max (performant pour la carte).
+  def results_by_city_id
+    @cities.index_by(&:id).transform_values { |city| for_city(city) }
+  end
+
+  def for_city(city)
+    index = self.class.weighted_index(city)
+    {
+      final_score: normalize_index(index).round(2),
+      weighted_index: index.round(4),
+      components: weighted_components(city),
+      caption: caption
+    }
+  end
+
+  def self.weighted_index(city)
+    train = city.TRAIN_valeur.to_f
+    metro = city.METRO_valeur.to_f
+    tram = city.TRAM_valeur.to_f
+    bus = city.BUS_valeur.to_f
+
+    (train * WEIGHTS[:train]) + (metro * WEIGHTS[:metro]) + (tram * WEIGHTS[:tram]) + (bus * WEIGHTS[:bus])
+  end
+
+  private
+
+  attr_reader :cities, :indices, :min, :max
+
+  def weighted_components(city)
+    {
+      train: (city.TRAIN_valeur.to_f * WEIGHTS[:train]).round(4),
+      metro: (city.METRO_valeur.to_f * WEIGHTS[:metro]).round(4),
+      tram: (city.TRAM_valeur.to_f * WEIGHTS[:tram]).round(4),
+      bus: (city.BUS_valeur.to_f * WEIGHTS[:bus]).round(4)
+    }
+  end
+
+  # Plus l'indice pondéré est élevé, meilleur est le score (plus d'arrêts / gares par habitant, modes lourds valorisés).
+  def normalize_index(index)
+    return 50.0 if max.nil? || min.nil? || max == min
+
+    100.0 * (index - min) / (max - min)
+  end
+
+  # Texte court pour l'UI : rappelle la formule sans jargon technique.
+  def caption
+    @caption ||= "Comparé aux autres villes affichées : train ×#{WEIGHTS[:train]}, métro ×#{WEIGHTS[:metro]}, " \
+      "tram ×#{WEIGHTS[:tram]}, bus ×#{WEIGHTS[:bus]} (stations / 1000 hab.), puis normalisation."
+  end
+end

--- a/app/views/maps/index.json.jbuilder
+++ b/app/views/maps/index.json.jbuilder
@@ -11,6 +11,10 @@
 # Un Feature = { type: "Feature", geometry: { type: "Point", coordinates: [lng, lat] }, properties: {} }
 # ATTENTION Mapbox : l'ordre des coordonnées est [LONGITUDE, LATITUDE] (inverse de l'intuition).
 
+# Score transports recalculé ici (pas la colonne CSV) : même périmètre que les villes affichées,
+# avec détail pédagogique pour les popups Mapbox — voir TransportNetworkScoreCalculator.
+transport_by_city = TransportNetworkScoreCalculator.new(@cities.to_a).results_by_city_id
+
 json.cities do
   json.type "FeatureCollection"
   json.features @cities do |city|
@@ -21,10 +25,19 @@ json.cities do
     end
     json.properties do
       json.id                      city.id
-      json.nom_com                 city.nom_com 
+      json.nom_com                 city.nom_com
+      # Alias attendu par map_controller.js (text-field, popups) — évite les undefined côté carte.
+      json.city_name               city.nom_com
       json.real_estate_score       city.real_estate_score
       json.job_market_score        city.job_market_score
-      json.transport_network_score city.transport_network_score
+      tn = transport_by_city.fetch(city.id)
+      json.transport_network_score   tn[:final_score]
+      json.transport_network_caption tn[:caption]
+      json.transport_component_bus   tn[:components][:bus]
+      json.transport_component_tram  tn[:components][:tram]
+      json.transport_component_metro tn[:components][:metro]
+      json.transport_component_train tn[:components][:train]
+      json.transport_weighted_index  tn[:weighted_index]
       json.activities_score        city.activities_score
       json.living_cost_score       city.living_cost_score
       json.education_score         city.education_score
@@ -37,7 +50,7 @@ json.cities do
       # Score composite = moyenne de tous les scores disponibles.
       # compact_blank retire les nil avant le calcul (sécurité si un score manque).
       scores = [
-        city.real_estate_score, city.job_market_score, city.transport_network_score,
+        city.real_estate_score, city.job_market_score, tn[:final_score],
         city.activities_score, city.living_cost_score, city.education_score,
         city.health_score, city.sunshine_score, city.outdoor_living_score,
         city.entertainment_score, city.cultural_heritage_score, city.commercial_life_score

--- a/test/services/transport_network_score_calculator_test.rb
+++ b/test/services/transport_network_score_calculator_test.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class TransportNetworkScoreCalculatorTest < ActiveSupport::TestCase
+  test "weighted index applique les poids train 4, metro 3, tram 2, bus 1" do
+    city = City.new(
+      TRAIN_valeur: 1,
+      METRO_valeur: 1,
+      TRAM_valeur: 1,
+      BUS_valeur: 1
+    )
+    # 4 + 3 + 2 + 1 = 10
+    assert_in_delta 10.0, TransportNetworkScoreCalculator.weighted_index(city), 0.0001
+  end
+
+  test "ville a indice minimal recoit 0 et indice maximal recoit 100 sur le scope" do
+    low = City.new(TRAIN_valeur: 0, METRO_valeur: 0, TRAM_valeur: 0, BUS_valeur: 0)
+    low.id = 1
+    high = City.new(TRAIN_valeur: 1, METRO_valeur: 0, TRAM_valeur: 0, BUS_valeur: 0)
+    high.id = 2
+    calc = TransportNetworkScoreCalculator.new([low, high])
+    assert_in_delta 0.0, calc.for_city(low)[:final_score], 0.01
+    assert_in_delta 100.0, calc.for_city(high)[:final_score], 0.01
+  end
+
+  test "indices identiques sur tout le scope donnent un score neutre 50" do
+    a = City.new(TRAIN_valeur: 2, METRO_valeur: 0, TRAM_valeur: 0, BUS_valeur: 0)
+    a.id = 1
+    b = City.new(TRAIN_valeur: 2, METRO_valeur: 0, TRAM_valeur: 0, BUS_valeur: 0)
+    b.id = 2
+    calc = TransportNetworkScoreCalculator.new([a, b])
+    assert_in_delta 50.0, calc.for_city(a)[:final_score], 0.01
+    assert_in_delta 50.0, calc.for_city(b)[:final_score], 0.01
+  end
+
+  test "results_by_city_id expose final_score et components pour chaque id" do
+    cities = [
+      City.new(id: 10, BUS_valeur: 1, TRAM_valeur: 0, METRO_valeur: 0, TRAIN_valeur: 0),
+      City.new(id: 20, BUS_valeur: 5, TRAM_valeur: 0, METRO_valeur: 0, TRAIN_valeur: 0)
+    ]
+    calc = TransportNetworkScoreCalculator.new(cities)
+    by_id = calc.results_by_city_id
+    assert_equal [10, 20].sort, by_id.keys.sort
+    assert by_id[10][:components].key?(:bus)
+    assert_match(/train ×4/i, by_id[10][:caption])
+  end
+
+  test "nil sur les valeurs est traite comme zero" do
+    city = City.new
+    city.id = 1
+    assert_in_delta 0.0, TransportNetworkScoreCalculator.weighted_index(city), 0.0001
+  end
+end


### PR DESCRIPTION
**Fichiers ajoutés**

- _app/services/transport_network_score_calculator.rb_ — service : indice pondéré (train×4, métro×3, tram×2, bus×1) sur *_valeur, normalisation min–max sur le scope des villes, hash par ville (final_score, weighted_index, components, caption).

- _test/services/transport_network_score_calculator_test.rb_ — tests Minitest (poids, min/max → 0 et 100, égalité → 50, results_by_city_id, valeurs nil → 0).

**Fichiers modifiés**

- _app/views/maps/index.json.jbuilder_ — calcul transport_by_city une fois pour toutes les @cities ; propriétés GeoJSON : transport_network_score (calculé), transport_network_caption, transport_component_{bus,tram,metro,train}, transport_weighted_index ; city_name alias de nom_com ; score composite basé sur le transport calculé (plus la colonne SQL).
- _app/javascript/controllers/map_controller.js_ — popup ville : score transports en gras + légende + ligne de détail des 4 composantes pondérées.
- _app/assets/stylesheets/pages/_map.scss_ — styles .map-popup__hint et .map-popup__breakdown pour ces blocs.
- _Gemfile_ — ajout gem "minitest", "~> 5.25" (Minitest 6 incompatible avec Rails 7.1 line_filtering).
- _Gemfile.lock_ — mise à jour après bundle update minitest (Minitest repassé en 5.x).

**Comportement**

- Le score transports affiché sur la carte et dans le score composite de /maps.json vient du calculateur Ruby, pas de cities.
- transport_network_score (colonne CSV / BDD inchangée mais non utilisée pour cet endpoint).
- La normalisation est relative aux villes chargées dans la réponse (même périmètre que @cities dans MapsController#index).

