### PR TITLE
Allow null latitude and longitude in cities

### DIFF
--- a/db/migrate/20260413073621_allow_null_for_latitude_and_longitude_in_cities.rb
+++ b/db/migrate/20260413073621_allow_null_for_latitude_and_longitude_in_cities.rb
@@ -1,0 +1,6 @@
+class AllowNullForLatitudeAndLongitudeInCities < ActiveRecord::Migration[7.1]
+  def change
+    change_column_null :cities, :latitude, true
+    change_column_null :cities, :longitude, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_04_10_105641) do
+ActiveRecord::Schema[7.1].define(version: 2026_04_13_073621) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -27,8 +27,8 @@ ActiveRecord::Schema[7.1].define(version: 2026_04_10_105641) do
     t.datetime "updated_at", null: false
     t.string "insee", null: false
     t.string "nom_com", null: false
-    t.float "latitude", null: false
-    t.float "longitude", null: false
+    t.float "latitude"
+    t.float "longitude"
     t.string "cv"
     t.string "nom_cv"
     t.string "dep"


### PR DESCRIPTION
Migration added
change made:
class AllowNullForLatitudeAndLongitudeInCities < ActiveRecord::Migration[7.1]
  def change
    change_column_null :cities, :latitude, true
    change_column_null :cities, :longitude, true
  end
end

Test: 
rails c + creation new city with lat+long null
test ok