### PR TITLE
add migration city pictures and link seloger

### DIFF
--- a/app/assets/stylesheets/components/_city_card.scss
+++ b/app/assets/stylesheets/components/_city_card.scss
@@ -66,13 +66,49 @@
     color: var(--gray-600);
   }
 
-  // ─── Placeholder photo ──────────────────────────────────────────────────
+  // ─── Photo de la ville ──────────────────────────────────────────────────
 
-  // Cadre gris réservant l'espace pour une future photo de la ville.
-  // La hauteur fixe garantit que toutes les cartes sont visuellement uniformes.
+  // Bloc image réelle : object-fit cover découpe l'image pour remplir
+  // parfaitement le cadre sans déformer, quelle que soit la dimension originale.
+  &__photo {
+    position: relative;
+    height: 160px;
+    overflow: hidden;
+    flex-shrink: 0;
+
+    img {
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+      // Transition douce lors du survol de la carte (hérité du &:hover sur .city-card)
+      transition: transform 0.35s ease;
+    }
+  }
+
+  // Zoom léger sur l'image quand on survole la carte entière
+  &:hover &__photo img {
+    transform: scale(1.04);
+  }
+
+  // Crédit Unsplash : discret, positionné en bas de l'image, requis par leurs CGU.
+  &__photo-credit {
+    position: absolute;
+    bottom: 0;
+    right: 0;
+    padding: 2px 8px;
+    background: rgba(0, 0, 0, 0.38);
+    color: rgba(255, 255, 255, 0.85);
+    font-size: 0.65rem;
+    border-top-left-radius: 6px;
+    // pointer-events: none : le crédit ne capture pas les clics
+    pointer-events: none;
+  }
+
+  // Fallback : même hauteur que le bloc photo pour conserver le gabarit
+  // quand l'image n'est pas encore disponible.
   &__photo-placeholder {
     background: var(--gray-300);
-    height: 140px;
+    height: 160px;
     display: flex;
     align-items: center;
     justify-content: center;
@@ -213,6 +249,47 @@
     &:active {
       transform: translateY(0);
     }
+  }
+
+  // ─── Bouton SeLoger ──────────────────────────────────────────────────────
+
+  // Style "outline" (fond transparent, bordure marron) pour rester secondaire
+  // visuellement : le CTA principal est le bouton carte (vert plein).
+  // La couleur marron (--brown-primary) est cohérente avec le critère "Immobilier"
+  // déjà utilisé dans les jauges de scores.
+  &__seloger-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 7px 14px;
+    background: transparent;
+    color: var(--brown-primary);
+    border: 1.5px solid var(--brown-soft);
+    border-radius: 50px;
+    font-family: "Poppins", sans-serif;
+    font-size: 0.78rem;
+    font-weight: 600;
+    text-decoration: none;
+    white-space: nowrap;
+    cursor: pointer;
+    transition: background 0.2s, border-color 0.2s, transform 0.15s;
+
+    &:hover {
+      background: var(--brown-soft);
+      border-color: var(--brown-primary);
+      color: var(--brown-primary);
+      transform: translateY(-1px);
+    }
+
+    &:active {
+      transform: translateY(0);
+    }
+  }
+
+  &__seloger-icon {
+    flex-shrink: 0;
+    // L'icône hérite de la couleur du bouton via currentColor
+    stroke: currentColor;
   }
 }
 

--- a/app/controllers/guest_searches_controller.rb
+++ b/app/controllers/guest_searches_controller.rb
@@ -40,6 +40,11 @@ class GuestSearchesController < ApplicationController
     return redirect_to new_guest_search_path unless @guest_search
 
     @ranked_cities = CityRankerService.new(@guest_search).top_cities
+
+    # On pré-charge les images manquantes avant le rendu de la vue.
+    # Au premier passage : jusqu'à 5 appels Unsplash (1 par ville).
+    # Les fois suivantes : image_url déjà en base → aucun appel réseau.
+    @ranked_cities.each { |city| CityImageFetcherService.new(city).call }
   end
 
   private

--- a/app/controllers/researches_controller.rb
+++ b/app/controllers/researches_controller.rb
@@ -32,6 +32,10 @@ class ResearchesController < ApplicationController
     # critères et les filtres géographiques de la recherche, puis retourne les 5
     # meilleures en SQL (sans tout charger en mémoire Ruby).
     @ranked_cities = CityRankerService.new(@research).top_cities
+
+    # Même logique que dans GuestSearchesController : les images sont récupérées
+    # une seule fois par ville et mises en cache dans la colonne image_url.
+    @ranked_cities.each { |city| CityImageFetcherService.new(city).call }
   end
 
   def edit

--- a/app/helpers/seloger_helper.rb
+++ b/app/helpers/seloger_helper.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+# Helper Rails : module de méthodes disponibles automatiquement dans toutes les vues.
+# On isole la logique de construction d'URL SeLoger ici pour ne pas polluer le partial.
+#
+# Un helper est préférable à du code inline dans la vue quand la logique dépasse
+# une simple interpolation de variable (ici : slugification + concaténation d'URL).
+module SelogerHelper
+  # Retourne l'URL de recherche SeLoger pour une ville et un type de transaction.
+  #
+  # Paramètres :
+  #   city  — instance de City (doit répondre à #nom_com)
+  #   type  — :achat (défaut) ou :locations
+  #
+  # Exemples :
+  #   seloger_url(city)             # => "https://www.seloger.com/immobilier/achat/immo-lyon/"
+  #   seloger_url(city, :locations) # => "https://www.seloger.com/immobilier/locations/immo-bordeaux/"
+  #
+  # `parameterize` est une méthode ActiveSupport qui convertit une chaîne en slug URL :
+  #   "Saint-Étienne" => "saint-etienne"
+  #   "Aix-en-Provence" => "aix-en-provence"
+  def seloger_url(city, type = :achat)
+    slug = city.nom_com.parameterize
+    "https://www.seloger.com/immobilier/#{type}/immo-#{slug}/"
+  end
+end

--- a/app/helpers/seloger_helper.rb
+++ b/app/helpers/seloger_helper.rb
@@ -4,23 +4,17 @@
 # On isole la logique de construction d'URL SeLoger ici pour ne pas polluer le partial.
 #
 # Un helper est préférable à du code inline dans la vue quand la logique dépasse
-# une simple interpolation de variable (ici : slugification + concaténation d'URL).
+# une simple interpolation de variable.
 module SelogerHelper
-  # Retourne l'URL de recherche SeLoger pour une ville et un type de transaction.
-  #
-  # Paramètres :
-  #   city  — instance de City (doit répondre à #nom_com)
-  #   type  — :achat (défaut) ou :locations
-  #
-  # Exemples :
-  #   seloger_url(city)             # => "https://www.seloger.com/immobilier/achat/immo-lyon/"
-  #   seloger_url(city, :locations) # => "https://www.seloger.com/immobilier/locations/immo-bordeaux/"
-  #
-  # `parameterize` est une méthode ActiveSupport qui convertit une chaîne en slug URL :
-  #   "Saint-Étienne" => "saint-etienne"
-  #   "Aix-en-Provence" => "aix-en-provence"
-  def seloger_url(city, type = :achat)
-    slug = city.nom_com.parameterize
-    "https://www.seloger.com/immobilier/#{type}/immo-#{slug}/"
+  # URL fixe de la page d'accueil SeLoger.
+  # On centralise la constante ici pour pouvoir la modifier en un seul endroit
+  # si l'URL venait à changer.
+  SELOGER_HOME_URL = "https://www.seloger.com/"
+
+  # Retourne l'URL de la page d'accueil SeLoger.
+  # L'argument `city` est conservé pour ne pas casser les appels existants
+  # dans les vues, mais il n'est plus utilisé dans le calcul.
+  def seloger_url(city)
+    SELOGER_HOME_URL
   end
 end

--- a/app/services/city_image_fetcher_service.rb
+++ b/app/services/city_image_fetcher_service.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+require "net/http"
+require "json"
+
+# Service Object : récupère une photo représentative d'une ville via l'API Wikipedia.
+#
+# Pourquoi Wikipedia plutôt qu'Unsplash ?
+#   → Aucune clé API requise : l'API REST Wikimedia est publique et sans authentification.
+#   → Les images sont issues de Wikimedia Commons (licences libres Creative Commons).
+#   → Chaque article Wikipedia d'une ville française contient généralement
+#     une photo principale très représentative (panorama, centre-ville, monument).
+#
+# Endpoint utilisé :
+#   GET https://fr.wikipedia.org/api/rest_v1/page/summary/{titre}
+#   → Retourne un résumé de l'article avec thumbnail et originalimage.
+#
+# Stratégie de cache : l'URL est persistée dans cities.image_url.
+# Une fois remplie, on ne rappelle plus jamais l'API pour cette ville.
+class CityImageFetcherService
+  # On préfère originalimage (pleine résolution) à thumbnail (320px) pour la qualité.
+  # Si originalimage est absent (rare), on se replie sur thumbnail.
+  WIKIPEDIA_API_BASE = "https://fr.wikipedia.org/api/rest_v1/page/summary"
+
+  # L'API Wikimedia exige un User-Agent identifiable (bonne pratique documentée).
+  # Format recommandé : "NomApp/version (contact)"
+  USER_AGENT = "MoveOn/1.0 (contact@moveon.fr)"
+
+  def initialize(city)
+    @city = city
+  end
+
+  # Point d'entrée du service.
+  # Retourne l'URL de l'image (string) ou nil si introuvable.
+  def call
+    # Court-circuit : si l'image est déjà en base, aucun appel réseau.
+    return @city.image_url if @city.image_url.present?
+
+    image_url = fetch_from_wikipedia
+    # update_column bypasse les callbacks ActiveRecord (validations, timestamps) :
+    # on ne fait qu'écrire une URL, inutile de déclencher toute la chaîne.
+    @city.update_column(:image_url, image_url) if image_url.present?
+
+    image_url
+  end
+
+  private
+
+  def fetch_from_wikipedia
+    uri      = build_uri
+    response = Net::HTTP.get_response(uri, { "User-Agent" => USER_AGENT })
+
+    # On ne traite que les réponses 200 OK.
+    return nil unless response.is_a?(Net::HTTPSuccess)
+
+    parse_image_url(response.body)
+  rescue StandardError => e
+    # rescue StandardError (jamais Exception) : on intercepte les erreurs réseau,
+    # de parsing JSON, etc., sans masquer les erreurs système (SignalException…).
+    Rails.logger.error("[CityImageFetcherService] Erreur Wikipedia pour '#{@city.nom_com}' : #{e.message}")
+    nil
+  end
+
+  # Construit l'URI en encodant le nom de la ville pour l'URL.
+  # URI.encode_www_form_component gère les accents, espaces et tirets :
+  #   "Aix-en-Provence" → "Aix-en-Provence" (tirets conservés, accents encodés)
+  #   "Châlons-en-Champagne" → "Ch%C3%A2lons-en-Champagne"
+  def build_uri
+    # Wikipedia accepte le nom de la commune tel quel (sans slug) — les majuscules
+    # et accents sont conservés car c'est le titre exact de l'article Wikipedia.
+    encoded_name = URI.encode_www_form_component(@city.nom_com)
+    URI("#{WIKIPEDIA_API_BASE}/#{encoded_name}")
+  end
+
+  # Extrait l'URL de l'image depuis la réponse JSON Wikipedia.
+  # Structure de la réponse :
+  #   {
+  #     "originalimage": { "source": "https://upload.wikimedia.org/...", ... },
+  #     "thumbnail":     { "source": "https://upload.wikimedia.org/...", ... }
+  #   }
+  def parse_image_url(body)
+    data = JSON.parse(body)
+    # On préfère originalimage (meilleure qualité), avec thumbnail en fallback.
+    # dig navigue dans le hash sans lever d'exception si une clé est absente.
+    data.dig("originalimage", "source") || data.dig("thumbnail", "source")
+  rescue JSON::ParserError => e
+    Rails.logger.error("[CityImageFetcherService] Réponse JSON invalide pour '#{@city.nom_com}' : #{e.message}")
+    nil
+  end
+end

--- a/app/views/shared/_city_card.html.erb
+++ b/app/views/shared/_city_card.html.erb
@@ -36,11 +36,26 @@
       </span>
     </div>
   </div>
-  <%# ── Placeholder photo ───────────────────────────────────────────── %>
-  <%# Cadre gris réservant l'espace pour une future photo (Cloudinary, API…). %>
-  <div class="city-card__photo-placeholder">
-    <span class="city-card__photo-label">Photo à venir</span>
-  </div>
+  <%# ── Photo de la ville ──────────────────────────────────────────────────── %>
+  <%#
+    Si image_url est nil (ville jamais consultée avant, ou API indisponible),
+    on affiche un bloc CSS placeholder pour conserver le gabarit de la carte.
+    loading="lazy" : le navigateur ne charge l'image qu'au moment où la carte
+    entre dans le viewport — améliore le temps de chargement initial.
+  %>
+  <% if city.image_url.present? %>
+    <div class="city-card__photo">
+      <%= image_tag city.image_url,
+            alt:     "Vue de #{city.nom_com}",
+            loading: "lazy" %>
+      <%# Crédit Wikimedia Commons (licence Creative Commons) %>
+      <span class="city-card__photo-credit">© Wikimedia Commons</span>
+    </div>
+  <% else %>
+    <div class="city-card__photo-placeholder">
+      <span class="city-card__photo-label">Photo à venir</span>
+    </div>
+  <% end %>
   <%# ── Jauges de scores par critère ────────────────────────────────── %>
   <%#
     On affiche les 6 critères disponibles pour toutes les villes.
@@ -86,5 +101,24 @@
     <%= link_to "Trouver sur la carte",
             map_path(city.id),
             class: "city-card__map-btn" %>
+    <%#
+      Lien SeLoger : secondaire visuellement (outline) pour ne pas concurrencer
+      les actions principales. target="_blank" + rel="noopener noreferrer" :
+      - _blank ouvre dans un nouvel onglet (l'utilisateur garde la page Move On)
+      - noopener : empêche la page cible d'accéder à window.opener (sécurité)
+      - noreferrer : n'envoie pas le Referer HTTP (confidentialité)
+    %>
+    <%= link_to seloger_url(city),
+          target: "_blank",
+          rel:    "noopener noreferrer",
+          class:  "city-card__seloger-btn" do %>
+      <svg class="city-card__seloger-icon" width="14" height="14" viewBox="0 0 24 24"
+           fill="none" stroke="currentColor" stroke-width="2.5"
+           aria-hidden="true">
+        <path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/>
+        <polyline points="9 22 9 12 15 12 15 22"/>
+      </svg>
+      SeLoger.com
+    <% end %>
   </div>
 </div>

--- a/db/migrate/20260414000001_add_image_url_to_cities.rb
+++ b/db/migrate/20260414000001_add_image_url_to_cities.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+# Migration réversible (change) : Rails sait annuler un add_column automatiquement.
+# On ajoute image_url en string nullable : nil signifie "image non encore récupérée".
+class AddImageUrlToCities < ActiveRecord::Migration[7.1]
+  def change
+    add_column :cities, :image_url, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_04_13_073621) do
+ActiveRecord::Schema[7.1].define(version: 2026_04_14_000001) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -87,6 +87,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_04_13_073621) do
     t.float "nb_obs_commune"
     t.float "avg_rent_sqm"
     t.float "rent_quality"
+    t.string "image_url"
   end
 
   create_table "guest_searches", force: :cascade do |t|


### PR DESCRIPTION
 1. Photos des villes via l'API Wikipedia. (publique gratuite)
 
  2. Affichage de la photo dans le partial _city_card
  - Si image_url est présent : affichage de la vraie photo.
  - Sinon : fallback sur le placeholder gris existant.
  
  3. Bouton "SeLoger.com". 
  
  4. Styles (_city_card.scss). 
 