### PR TITLE
Fix: Affichage POI, validation nom recherche, limites communales

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@
 
 .cursorignore
 db/communes_fr.geojson
+db/POI_VF.csv

--- a/app/controllers/maps_controller.rb
+++ b/app/controllers/maps_controller.rb
@@ -134,7 +134,7 @@ class MapsController < ApplicationController
     end
 
     @ranked_cities = CityRankerService.new(search).top_cities
-    @poi_kinds     = selected_poi_kinds(search)
+    @poi_kinds     = []  # Vide : on affiche tous les POI
     @search_name   = search.research_name.presence || "Vos résultats"
 
     # Données minimales des 5 villes sérialisées pour le controller Stimulus (inline JSON).

--- a/app/controllers/search_steps_controller.rb
+++ b/app/controllers/search_steps_controller.rb
@@ -45,6 +45,15 @@ class SearchStepsController < ApplicationController
       @research.assign_attributes(details_params)
       @research.user ||= current_user   # association user déjà initialisée par build, mais sécurité
       authorize @research, :update?
+      
+      # Vérifie l'unicité du nom avant de sauvegarder
+      if @research.research_name.present? && 
+         current_user.researches.where.not(id: @research.id).exists?(research_name: @research.research_name)
+        @research.errors.add(:research_name, "existe déjà. Veuillez choisir un autre nom.")
+        @regions = City.distinct.order(:nom_reg).pluck(:nom_reg).compact
+        return render_wizard
+      end
+      
       @research.save(validate: false)   # sauvegarde partielle : le nom peut encore être vide
       session[:wizard_research_id] = @research.id
 

--- a/app/javascript/controllers/map_controller.js
+++ b/app/javascript/controllers/map_controller.js
@@ -48,11 +48,11 @@ export default class extends Controller {
     // poiKinds : critères essentiels sélectionnés — propagés dans les liens
     // des popups des autres villes pour conserver le filtre ?kinds=…
     poiKinds: { type: Array, default: [] },
-    // researchId : identifiant de la recherche utilisateur (connecté uniquement),
-    // transmis dans les liens des popups pour que le prochain maps#show puisse
-    // recharger le contexte et, à son tour, afficher les 4 autres villes.
-    // Vide pour les visiteurs (le fallback se fait via session[:guest_search_id]).
-    researchId: { type: String, default: "" },
+    // researchId : identifiant de la recherche, propagé dans les popups
+    // pour préserver le contexte de navigation.
+    researchId: String,
+    // insee : code INSEE de la commune pour charger les limites administratives
+    insee: String,
     // pinUrl : URL de l'image custom utilisée comme marqueur fallback (rank inconnu).
     // Passée depuis la vue ERB via asset_path pour bénéficier du fingerprinting Assets.
     pinUrl: { type: String, default: "" }
@@ -71,18 +71,16 @@ export default class extends Controller {
     health: "Santé"
   }
 
-  // ── Couleurs par kind de POI — cohérentes avec la légende de maps/show.html.erb ──
-  // Les 3 kinds réellement affichés (sport, loisir, culture) reprennent exactement
-  // les couleurs de la légende pour que marqueurs et légende soient identiques.
-  // Attention : le kind en base est "loisir" (sans 's') — voir migration NormalizePoiKinds.
+  // ── Couleurs par kind de POI — cohérentes avec la palette Move On ──────────
+  // On définit les couleurs ici pour les réutiliser dans la légende ET dans les layers.
   static POI_COLORS = {
-    sport: "#EF5350",   // rouge — Équipements sportifs
-    loisir: "#E57373",  // rouge clair — Équipements de loisirs
-    culture: "#9575CD", // violet — Équipements culturels et socioculturels
+    sport: "#7CB342", // --green-primary
+    culture: "#4FC3F7", // --blue-primary
+    loisirs: "#558B2F", // --green-dark
     commerce: "#FFCA28", // --yellow-accent
     transport: "#0288D1", // --blue-dark
     education: "#8D6E63", // --brown-primary
-    health: "#2E9EAD"   // --blue-teal
+    health: "#2E9EAD"  // --blue-teal
   }
 
   connect() {
@@ -130,6 +128,9 @@ export default class extends Controller {
       // Pastilles des critères essentiels — matérialisent les 3 critères "must-have"
       // du user directement sur la carte, quel que soit l'état des données POI.
       if (this.essentialKindsValue.length > 0) this.addEssentialDots()
+
+      // Charge les limites communales si un code INSEE est fourni
+      if (this.inseeValue) this.loadCommuneBoundary()
 
       if (this.poisValue.length > 0) {
         // Vue show : les POIs ont été pré-filtrés et sérialisés côté serveur (maps#show).
@@ -313,8 +314,8 @@ export default class extends Controller {
       const angle = (index / kinds.length) * 2 * Math.PI - Math.PI / 2
       // Correction de la longitude par cos(lat) pour éviter que le cercle
       // soit écrasé aux latitudes élevées (projection Web Mercator).
-      const lng = center.lng + (radius * Math.cos(angle)) / Math.cos(center.lat * Math.PI / 180)
-      const lat = center.lat + radius * Math.sin(angle)
+      const lng   = center.lng + (radius * Math.cos(angle)) / Math.cos(center.lat * Math.PI / 180)
+      const lat   = center.lat + radius * Math.sin(angle)
 
       const color = this.constructor.POI_COLORS[kind] || "#757575"
       const label = this.constructor.POI_LABELS[kind] || kind
@@ -332,6 +333,58 @@ export default class extends Controller {
         .setLngLat([lng, lat])
         .addTo(this.map)
     })
+  }
+
+  // ── Chargement des limites communales via API IGN
+  // ────────────────────────────────────────────────────────────────────────────
+
+  async loadCommuneBoundary() {
+    try {
+      const inseeCode = this.inseeValue.toString().padStart(5, '0')
+      const response = await fetch(`https://apicarto.ign.fr/api/cadastre/commune?code_insee=${inseeCode}`)
+      
+      if (!response.ok) {
+        console.warn(`[MapController] Impossible de charger les limites pour INSEE ${inseeCode}`)
+        return
+      }
+
+      const data = await response.json()
+      
+      if (data.features && data.features.length > 0) {
+        // Ajoute la source GeoJSON des limites communales
+        this.map.addSource('commune-boundary', {
+          type: 'geojson',
+          data: data
+        })
+        
+        // Remplissage semi-transparent
+        this.map.addLayer({
+          id: 'commune-fill',
+          type: 'fill',
+          source: 'commune-boundary',
+          paint: {
+            'fill-color': '#2E9EAD',
+            'fill-opacity': 0.08
+          }
+        })
+        
+        // Contour de la commune
+        this.map.addLayer({
+          id: 'commune-outline',
+          type: 'line',
+          source: 'commune-boundary',
+          paint: {
+            'line-color': '#2E9EAD',
+            'line-width': 2.5,
+            'line-opacity': 0.7
+          }
+        })
+        
+        console.log(`[MapController] Limites communales chargées pour ${inseeCode}`)
+      }
+    } catch (error) {
+      console.error('[MapController] Erreur lors du chargement des limites communales:', error)
+    }
   }
 
   // ── Layer VILLES ──────────────────────────────────────────────────────────
@@ -471,13 +524,12 @@ export default class extends Controller {
       filter: ["!", ["has", "point_count"]], // exclut les clusters
       paint: {
         "circle-radius": 7,
-        // match compare la propriété "kind" à une liste de cas, avec un fallback gris.
-        // Les couleurs sont synchronisées avec static POI_COLORS ET la légende de maps/show.html.erb.
+        // match compare la propriété "kind" à une liste de cas, avec un fallback gris
         "circle-color": [
           "match", ["get", "kind"],
-          "sport", "#EF5350",  // rouge — Équipements sportifs
-          "loisir", "#E57373",  // rouge clair — Équipements de loisirs
-          "culture", "#9575CD",  // violet — Équipements culturels et socioculturels
+          "sport", "#7CB342",
+          "culture", "#4FC3F7",
+          "nature", "#558B2F",
           "commerce", "#FFCA28",
           "transport", "#0288D1",
           "education", "#8D6E63",
@@ -531,11 +583,11 @@ export default class extends Controller {
           <li>
             Transports : <strong>${props.transport_network_score}</strong>
             ${props.transport_network_caption
-        ? `<div class="map-popup__hint">${props.transport_network_caption}</div>`
-        : ""}
+              ? `<div class="map-popup__hint">${props.transport_network_caption}</div>`
+              : ""}
             ${props.transport_component_train != null
-        ? `<div class="map-popup__breakdown">Train ×4 : ${props.transport_component_train} · Métro ×3 : ${props.transport_component_metro} · Tram ×2 : ${props.transport_component_tram} · Bus : ${props.transport_component_bus}</div>`
-        : ""}
+              ? `<div class="map-popup__breakdown">Train ×4 : ${props.transport_component_train} · Métro ×3 : ${props.transport_component_metro} · Tram ×2 : ${props.transport_component_tram} · Bus : ${props.transport_component_bus}</div>`
+              : ""}
           </li>
           <li>Éducation : ${props.education_score}</li>
           <li>Santé : ${props.health_score}</li>
@@ -547,7 +599,7 @@ export default class extends Controller {
 
   poiPopupHtml(props) {
     const colors = {
-      sport: "#EF5350", culture: "#9575CD", loisir: "#E57373", nature: "#558B2F",
+      sport: "#7CB342", culture: "#4FC3F7", nature: "#558B2F",
       commerce: "#FFCA28", transport: "#0288D1", education: "#8D6E63", health: "#2E9EAD"
     }
     const color = colors[props.kind] || "#757575"

--- a/app/policies/city_policy.rb
+++ b/app/policies/city_policy.rb
@@ -5,6 +5,10 @@ class CityPolicy < ApplicationPolicy
   # code, beware of possible changes to the ancestors:
   # https://gist.github.com/Burgestrand/4b4bc22f31c8a95c425fc0e30d7ef1f5
 
+  def index?
+    true
+  end
+
   def show?
     true
   end

--- a/app/views/maps/results.html.erb
+++ b/app/views/maps/results.html.erb
@@ -64,7 +64,6 @@
             On construit le hash progressivement pour éviter un ?kinds= vide dans l'URL.
         %>
         <% city_map_params = { rank: rank }
-           city_map_params[:kinds] = @poi_kinds.join(",") if @poi_kinds.any?
            # Pour les utilisateurs connectés, on propage research_id afin que
            # maps#show puisse recharger la recherche et afficher les 4 autres
            # villes classées sur la carte (visibles au dézoom).

--- a/app/views/maps/show.html.erb
+++ b/app/views/maps/show.html.erb
@@ -5,40 +5,63 @@
   <link href="https://api.mapbox.com/mapbox-gl-js/v3.11.0/mapbox-gl.css" rel="stylesheet" />
   <script src="https://api.mapbox.com/mapbox-gl-js/v3.11.0/mapbox-gl.js"></script>
 <% end %>
+
 <div class="map-page">
   <div class="map-page__sidebar">
     <h1 class="map-page__title"><%= @city.nom_com %></h1>
     <p class="map-page__description">
       <%= [@city.nom_dep, @city.nom_reg].compact.join(" · ") %>
     </p>
+
+    <%# Lien retour — history.back() permet de revenir à la page précédente (résultats ou carte résultats) %>
+    <button type="button" data-controller="back" data-action="click->back#back" class="map-page__back-link">
+      ← Retour
+    </button>
+
+    <%# Légende POI %>
     <div class="map-legend">
       <h2 class="map-legend__title">Légende</h2>
+      
       <section class="map-legend__section">
         <h3 class="map-legend__subtitle">Villes — Dynamisme</h3>
         <ul class="map-legend__list">
-          <li><span class="map-legend__dot" style="background:#0288D1"></span> Nombre de points d'intérêts élevé  </li>
-          <li><span class="map-legend__dot" style="background:#4FC3F7"></span> Nombre de points d'intérêts moyen  </li>
-          <li><span class="map-legend__dot" style="background:#B3E5FC"></span> Nombre de points d'intérêts faible </li>
-          <li class="map-legend__note">La taille du cercle reflète aussi le score.</li>
+          <li>
+            <span class="map-legend__dot" style="background:#0288D1; width:16px; height:16px;"></span>
+            Nombre de points d'intérêts élevé
+          </li>
+          <li>
+            <span class="map-legend__dot" style="background:#4FC3F7; width:12px; height:12px;"></span>
+            Nombre de points d'intérêts moyen
+          </li>
+          <li>
+            <span class="map-legend__dot" style="background:#B3E5FC; width:8px; height:8px;"></span>
+            Nombre de points d'intérêts faible
+          </li>
         </ul>
+        <p class="map-legend__note">
+          La taille du cercle reflète aussi le score.
+        </p>
       </section>
+
       <section class="map-legend__section">
         <h3 class="map-legend__subtitle">Points d'intérêt</h3>
         <ul class="map-legend__list">
-          <li><span class="map-legend__dot" style="background:#EF5350"></span> Équipements sportifs</li>
-          <li><span class="map-legend__dot" style="background:#E57373"></span> Équipements de loisirs</li>
-          <li><span class="map-legend__dot" style="background:#9575CD"></span> Équipements culturels et socioculturels</li>
+          <li>
+            <span class="map-legend__dot" style="background:#7CB342"></span>
+            Équipements sportifs
+          </li>
+          <li>
+            <span class="map-legend__dot" style="background:#4FC3F7"></span>
+            Équipements culturels et socioculturels
+          </li>
         </ul>
         <p class="map-legend__note">
           Les cercles bleus sont des groupes — cliquez pour zoomer et les éclater.
         </p>
       </section>
     </div>
-    <%# Lien retour — history.back() permet de revenir à la page précédente (résultats ou carte résultats) %>
-    <button type="button" data-controller="back" data-action="click->back#back" class="btn-hero-primary">
-      ← Retour
-    </button>
   </div>
+
   <%#
     Conteneur Mapbox — piloté par map_controller.js.
 
@@ -79,5 +102,6 @@
     data-map-poi-kinds-value="<%= @poi_kinds.to_json %>"
     data-map-research-id-value="<%= @research_id_param %>"
     data-map-pois-value="<%= @pois_features.to_json %>"
+    data-map-insee-value="<%= @city.insee %>"
   ></div>
 </div>

--- a/app/views/search_steps/details.html.erb
+++ b/app/views/search_steps/details.html.erb
@@ -32,7 +32,7 @@
       form_with avec une URL manuelle (wizard_path = URL de l'étape courante).
       method: :patch car Wicked utilise PATCH pour avancer dans le wizard.
     %>
-    <%= form_with url: wizard_path, method: :patch, html: { class: 'wizard-form' } do |f| %>
+    <%= form_with url: wizard_path, method: :patch, html: { class: 'wizard-form' }, data: { turbo: false } do |f| %>
       <%# ── A) Nom de la recherche ───────────────────────────────── %>
       <div class="wizard-field-group">
         <label for="research_research_name" class="wizard-field-label">
@@ -52,6 +52,11 @@
                class="wizard-text-input"
                required
                autocomplete="off">
+        <% if @research.errors[:research_name].any? %>
+          <p style="color: #E53935; font-size: 0.875rem; margin-top: 0.5rem;">
+            ⚠️ <%= @research.errors[:research_name].first %>
+          </p>
+        <% end %>
         <p class="wizard-field-hint">Ce nom vous permettra de retrouver et comparer vos recherches.</p>
       </div>
       <%# ── B) Filtres géographiques ─────────────────────────────── %>

--- a/app/views/shared/_city_card.html.erb
+++ b/app/views/shared/_city_card.html.erb
@@ -98,35 +98,13 @@
       </div>
     <% end %>
   </div>
-  <%#
-    Calcule les kinds de POI correspondant aux critères "essentiels" (valeur = 3)
-    de la recherche. Seuls les critères ayant un kind de POI associé sont retenus
-    (ex : real_estate n'a pas de POI dédié → exclu du mapping).
-    Ces kinds sont passés en query param à maps#show pour filtrer l'affichage.
-  %>
-  <% poi_kind_mapping = {
-       transport_network:   "transport",
-       cultural_heritage:   "culture",
-       health:              "health",
-       commercial_life:     "commerce",
-       leisures_and_sports: "sport",
-       education:           "education"
-     }
-     essential_kinds = poi_kind_mapping.filter_map do |key, kind|
-       kind if search.respond_to?(key) && search.public_send(key).to_i == 3
-     end
-     #
-     # On propage le rang (index) à maps#show via le query param ?rank=
-     # pour que la carte ville-unique puisse afficher le même marqueur coloré
-     # + numéroté que sur la carte des 5 résultats.
-     map_query_params = {}
-     map_query_params[:kinds] = essential_kinds.join(",") if essential_kinds.any?
-     city_map_url = map_path(city.id, map_query_params) %>
+  <%# Lien vers la carte de la ville - affiche TOUS les POI sans filtrage %>
+  <% city_map_url = map_path(city.id) %>
 
   <%# ── Actions ──────────────────────────────────────────────────────── %>
   <div class="city-card__actions">
     <%# Bouton "Trouver sur la carte" – ouvre la carte centrée sur cette ville
-        avec uniquement les POIs des critères essentiels du user (?kinds=…) %>
+        avec tous les POIs disponibles (sport + culture) %>
     <%= link_to "Trouver sur la carte",
             city_map_url,
             class: "city-card__map-btn" %>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -11,8 +11,6 @@ City.destroy_all
 puts "📊 Import des communes depuis BD_MOVE_ON_20260417.csv..."
 
 csv_file = Rails.root.join('db', 'BD_MOVE_ON_20260417.csv')
-count = 0
-errors = 0
 
 # Fonction pour corriger l'encodage des caractères (UTF-8 mal interprété comme Latin-1)
 def fix_encoding(text)
@@ -38,9 +36,15 @@ def parse_int(value)
   value.to_i
 end
 
+batch_size = 5000  # Augmenté pour maximiser la performance
+cities_batch = []
+count = 0
+errors = 0
+start_time = Time.now
+
 CSV.foreach(csv_file, headers: true, encoding: 'UTF-8') do |row|
   begin
-    City.create!(
+    cities_batch << {
       # Identifiants
       insee: row['insee'],
       code_posta: row['code_posta'],
@@ -74,7 +78,6 @@ CSV.foreach(csv_file, headers: true, encoding: 'UTF-8') do |row|
       count_coll: parse_int(row['count_coll']),
       count_lyce: parse_int(row['count_lyce']),
       nb_creche: parse_int(row['nb_creche']),
-
 
       # Économie
       rev_median: parse_int(row['rev_median']),
@@ -131,26 +134,44 @@ CSV.foreach(csv_file, headers: true, encoding: 'UTF-8') do |row|
       real_estate_score: parse_float(row['score_immo']),
       outdoor_living_score: parse_float(row['score_grand_air']),
       sunshine_score: parse_float(row['score_pluviometrie']),
-    )
+      created_at: Time.current,
+      updated_at: Time.current
+    }
 
-    count += 1
-    print "\r  ✓ #{count} communes importées..." if count % 1000 == 0
+    # Insertion par batch
+    if cities_batch.size >= batch_size
+      City.insert_all(cities_batch)
+      count += cities_batch.size
+      cities_batch = []
+      
+      elapsed = Time.now - start_time
+      rate = count / elapsed
+      print "\r✓ #{count} communes importées (#{rate.round(0)} communes/sec)..."
+    end
   rescue => e
     errors += 1
-    puts "\n  ⚠️  Erreur pour #{row['nom_com']} (#{row['insee']}): #{e.message}"
+    puts "\n⚠️  Erreur pour #{row['nom_com']} (#{row['insee']}): #{e.message}"
   end
 end
 
-puts "\n\n✅ Seeds terminées : #{City.count} communes importées (#{errors} erreurs)"
+# Insertion du dernier batch
+if cities_batch.any?
+  City.insert_all(cities_batch)
+  count += cities_batch.size
+end
+
+elapsed = Time.now - start_time
+puts "\n\n✅ Seeds terminées : #{City.count} communes importées (#{errors} erreurs) en #{elapsed.round(1)}s (#{(count / elapsed).round(0)} communes/sec)"
 
 # Normalisation des kinds de POI : le CSV BPE24 utilise des libellés français longs,
 # mais le reste de l'app (map_controller.js, MapsController) attend des identifiants
 # courts en anglais pour les couleurs et les filtres de recherche.
 # Ce mapping doit être mis à jour si de nouveaux types sont importés.
 POI_KIND_NORMALIZATION = {
+POI_KIND_NORMALIZATION = {
   "Equipements culturels et socioculturels" => "culture",
-  "Equipements de loisirs"                 => "loisir",
-  "Equipements sportifs" => "sport"
+  "Equipements sportifs"                   => "sport",
+  "Equipements de loisirs"                 => "sport"
   # Ajouter ici les autres types au fur et à mesure de leur import :
   # "Equipements de santé"   => "health",
   # "Equipements de transport" => "transport",
@@ -160,63 +181,79 @@ POI_KIND_NORMALIZATION = {
 }.freeze
 
 puts "📍 Import des Points d'Intérêt (POI)..."
-print "❓ Souhaitez-vous importer les Points d'Intérêt (POI.csv) ? Cela peut prendre du temps. (y/n) : "
+print "❓ Souhaitez-vous importer les Points d'Intérêt (POI_VF.csv) ? Cela peut prendre du temps. (y/n) : "
 reponse = STDIN.gets.chomp.downcase
 if reponse != 'y' && reponse != 'o'
   puts "🚫 Import annulé par l'utilisateur."
 else
-  puts "🚀 Lancement de l'import..."
-  # On prépare le cache en nettoyant les clés (on enlève les espaces et on force 5 chiffres)
+  puts "🚀 Lancement de l'import optimisé..."
+  
+  # Cache des cities
   cities_cache = City.all.each_with_object({}) do |city, hash|
     clean_insee = city.insee.to_s.strip.rjust(5, '0')
     hash[clean_insee] = city.id
   end
 
-  poi_file = Rails.root.join('db', 'POI220426.csv')
+  # Utilisation du fichier local uniquement
+  poi_file = Rails.root.join('db', 'POI_VF.csv')
+  
+  unless File.exist?(poi_file)
+    abort("� Fichier POI_VF.csv introuvable dans db/. Veuillez le placer dans le dossier db/ avant de lancer la seed.")
+  end
+  
+  puts "📂 Utilisation du fichier local : #{poi_file}"
+  batch_size = 5000  # Insère 5000 POI à la fois pour maximiser la performance
+  poi_batch = []
   poi_count = 0
   poi_errors = 0
+  
+  start_time = Time.now
 
-  # On utilise "bom|utf-8" pour supprimer les caractères invisibles de début de fichier
   CSV.foreach(poi_file, headers: true, col_sep: ';', encoding: 'bom|utf-8') do |row|
     begin
-      # On cherche la colonne INSEE de manière flexible (au cas où le nom varie)
-      raw_insee = row['#Code_commune_INSEE'] || row.to_h.values.last # secours sur la dernière colonne
-
+      raw_insee = row['#Code_commune_INSEE'] || row.to_h.values.last
       insee_csv = raw_insee.to_s.strip.rjust(5, '0')
       city_id = cities_cache[insee_csv]
 
       if city_id
-        # Utilisation de .send pour bypasser les problèmes de mapping si nécessaire
-        poi = PointOfInterest.new(
+        poi_batch << {
           city_id:     city_id,
           name:        row['NOMRS'] || "Sans nom",
           latitude:    row['LATITUDE'].to_s.gsub(',', '.').to_f,
           longitude:   row['LONGITUDE'].to_s.gsub(',', '.').to_f,
           postal_code: row['CODPOS'],
           category:    row['BPE24_varmod.LIB_MOD'],
-          # On normalise le kind vers un identifiant court anglais pour la cohérence
-          # avec map_controller.js et les filtres de recherche.
           kind:        POI_KIND_NORMALIZATION.fetch(row['BPE24_varmod.LIB_MOD.1'], row['BPE24_varmod.LIB_MOD.1']),
-          public:      true
-        )
-
-        if poi.save
-          poi_count += 1
-        else
-          # Affiche pourquoi le POI est refusé par le modèle (ex: validations)
-          puts "❌ Erreur validation : #{poi.errors.full_messages}" if poi_errors < 5
-          poi_errors += 1
+          public:      true,
+          created_at:  Time.current,
+          updated_at:  Time.current
+        }
+        
+        # Insertion par batch pour performance maximale
+        if poi_batch.size >= batch_size
+          PointOfInterest.insert_all(poi_batch)
+          poi_count += poi_batch.size
+          poi_batch = []
+          
+          elapsed = Time.now - start_time
+          rate = poi_count / elapsed
+          print "\r✓ #{poi_count} POI importés (#{rate.round(0)} POI/sec)..."
         end
       else
         poi_errors += 1
       end
     rescue => e
-      puts "❌ Erreur système : #{e.message}" if poi_errors < 5
+      puts "\n❌ Erreur système : #{e.message}" if poi_errors < 5
       poi_errors += 1
     end
-
-    print "\rProgression : #{poi_count + poi_errors}..." if ((poi_count + poi_errors) % 500).zero?
   end
 
-  puts "\n\n✅ Résultat : #{poi_count} créés / #{poi_errors} échoués."
+  # Insertion du dernier batch
+  if poi_batch.any?
+    PointOfInterest.insert_all(poi_batch)
+    poi_count += poi_batch.size
+  end
+
+  elapsed = Time.now - start_time
+  puts "\n\n✅ Résultat : #{poi_count} créés / #{poi_errors} échoués en #{elapsed.round(1)}s (#{(poi_count / elapsed).round(0)} POI/sec)"
 end


### PR DESCRIPTION
Affichage des POIs :
app/views/shared/_city_card.html.erb : Suppression du filtrage par kinds, tous les POI s'affichent maintenant
app/controllers/maps_controller.rb : @poi_kinds = [] dans la méthode results
app/views/maps/results.html.erb : Suppression de la ligne city_map_params[:kinds] = ...
>>>Les liens "Voir les points d'intérêt" n'ont plus de paramètre ?kinds= et affichent tous les POI disponibles (sport + culture)

Ajout des limites communales :
app/views/maps/show.html.erb : Ajout de data-map-insee-value + restauration de la légende POI
app/javascript/controllers/map_controller.js :
- Nouvelle méthode loadCommuneBoundary() qui appelle l'API IGN Cadastre
- Affiche un contour bleu-vert (#2E9EAD) autour de la commune
- Gestion d'erreur silencieuse si l'API est indisponible

Noms de recherche dupliqués :
app/controllers/search_steps_controller.rb :
- Vérification de l'unicité du nom avant sauvegarde
- Définition de @regions pour éviter les erreurs de re-render
- Message d'erreur explicite si le nom existe déjà
app/views/search_steps/details.html.erb :
- Désactivation de Turbo (data: { turbo: false })
- Affichage du message d'erreur sous le champ research_name

Adaptation du seed.rb : faire passer plus rapidement par batch de 5000
- Réduction de la durée de la seed
- Ajout de "Equipements de loisirs" => "sport" dans POI_KIND_NORMALIZATION